### PR TITLE
gnulib, sim: don't use strsignal and errno on WinCE

### DIFF
--- a/gdb/gnulib/import/canonicalize-lgpl.c
+++ b/gdb/gnulib/import/canonicalize-lgpl.c
@@ -107,7 +107,7 @@ alloc_failed (void)
 #if (defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__
   /* Avoid errno problem without using the malloc or realloc modules; see:
      http://lists.gnu.org/archive/html/bug-gnulib/2016-08/msg00025.html  */
-  errno = ENOMEM;
+  __set_errno (ENOMEM);
 #endif
 }
 

--- a/sim/common/nrun.c
+++ b/sim/common/nrun.c
@@ -215,8 +215,12 @@ main (int argc, char **argv)
     case sim_signalled:
     case sim_stopped:
       if (sigrc != 0)
+#ifdef UNDER_CE
+	fprintf (stderr, "program stopped with signal %d.\n", sigrc);
+#else
 	fprintf (stderr, "program stopped with signal %d (%s).\n", sigrc,
 		 strsignal (sigrc));
+#endif
       break;
 
     case sim_exited:


### PR DESCRIPTION
Fix build errors that occur when building binutils using MSYS2 64-bit gcc 7.2 on Windows.